### PR TITLE
Automatically Renew Certificates

### DIFF
--- a/nginx.yml
+++ b/nginx.yml
@@ -44,6 +44,12 @@
         creates: /etc/letsencrypt/live/{{ ansible_host }}/cert.pem
       notify: reload nginx
 
+    - name: certbot-renew enabled and started
+      service:
+        name: certbot-renew.timer
+        state: started
+        enabled: true
+
     - name: install diffie hellmann paramter
       copy:
         src: nginx/dhparam.pem


### PR DESCRIPTION
This patch makes certbot automatically renew TLS certificates by
enabling the certbot-renew timer.