### PR TITLE
Fix RHEL Package Name

### DIFF
--- a/emissions-api.yml
+++ b/emissions-api.yml
@@ -15,7 +15,7 @@
     - name: install RedHat specific software
       package:
         name:
-          - cmake3
+          - cmake
           - gcc
           - make
           - libcurl-devel


### PR DESCRIPTION
The `cname3` package now seems to be named `cname`.