### PR TITLE
Update git branch

### DIFF
--- a/emissions-api.yml
+++ b/emissions-api.yml
@@ -49,6 +49,8 @@
       git:
         repo: https://github.com/emissions-api/emissions-api.git
         dest: /opt/emissions-api/emissions-api/
+        update: true
+        version: main
       notify:
         restart emissionsapi-web
 


### PR DESCRIPTION
This patch makes the deployment use the correct branch when updating
Emissions API which is now `main`.